### PR TITLE
Fixed additional week08 slide typo/mistake - missing semicolon

### DIFF
--- a/slides/08-databases.md
+++ b/slides/08-databases.md
@@ -400,7 +400,7 @@ pub fn establish_connection() -> PgPool {
          .expect("DATABASE_URL must be set");
          
     PgConnection::establish(&database_url)
-        .expect(&format!("Error connecting to {}", database_url))
+        .expect(&format!("Error connecting to {}", database_url));
         
     init_pool(&database_url).expect("Failed to create pool")
 }


### PR DESCRIPTION
Found this while copy-pasting. Current code results in 'error: expected one of `.`, `;`, `?`, `}`, or an operator, found `init_pool`', because of course we do not want to return .expect().